### PR TITLE
Make magicpen-prism a peer dependency and try it on semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
     "documentation"
   ],
   "peerDependencies": {
+    "magicpen-prism": "^2.2.1",
     "unexpected": "*"
   },
   "dependencies": {
     "async": "1.4.0",
     "escodegen": "1.7.0",
     "esprima": "2.6.0",
-    "magicpen-prism": "2.2.1",
+    "magicpen-prism": "^2.2.1",
     "marked-papandreou": "0.3.3-patch3",
     "passerror": "1.1.0",
     "source-map": "0.5.1"


### PR DESCRIPTION
I want magicpen-prism to be a peer dependency all the way out of unexpected-documentation-site-generator and at the same time provide a default version if not specified.