### PR TITLE
Support babel transpiling when generating html and updating snippets

### DIFF
--- a/lib/UnexpectedMarkdown.js
+++ b/lib/UnexpectedMarkdown.js
@@ -9,27 +9,17 @@ var fs = require('fs');
 var pathModule = require('path');
 var convertMarkdownToMocha = require('./convertMarkdownToMocha');
 var sourceMap = require('source-map');
+var locateBabelrc = require('./locateBabelrc');
 
 var fs = require('fs');
 var babelCore;
+var babelOptions;
 try {
     babelCore = require.main.require('babel-core');
-} catch (e) {}
-
-var babelOptions;
-if (babelCore) {
-    var dirFragments = pathModule.dirname(require.main.filename).split(pathModule.sep).slice(1);
-    for (var i = dirFragments.length ; i >= 0 ; i -= 1) {
-        var tryBabelRcPath = pathModule.resolve('/' + dirFragments.slice(0, i).join(pathModule.sep), '.babelrc');
-        var stats = null;
-        try {
-            stats = fs.statSync(tryBabelRcPath);
-        } catch (e) {}
-        if (stats && stats.isFile()) {
-            babelOptions = JSON.parse(fs.readFileSync(tryBabelRcPath, 'utf-8'));
-            break;
-        }
-    }
+    var babelrc = locateBabelrc();
+    babelOptions = JSON.parse(fs.readFileSync(babelrc, 'utf-8'));
+} catch (e) {
+    babelCore = null;
 }
 
 var maps = {};

--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -2,7 +2,27 @@
 var async = require('async');
 var extend = require('./extend');
 var vm = require('vm');
+var fs = require('fs')
 var createExpect = require('./createExpect');
+var locateBabelrc = require('./locateBabelrc');
+
+var transpile;
+try {
+    var babelCore = require.main.require('babel-core');
+    var babelrc = locateBabelrc();
+    var babelOptions = JSON.parse(fs.readFileSync(babelrc, 'utf-8'));
+
+    transpile = function transpile(code) {
+        var babelResult = babelCore.transform(code, extend({}, babelOptions, {
+            sourceMaps: false,
+        }));
+        return babelResult.code;
+    };
+} catch (e) {
+    transpile = function transpile (code) {
+        return code;
+    };
+}
 
 function isPromise(value) {
     return value &&
@@ -38,10 +58,9 @@ module.exports = function (snippets, options, cb) {
                     global.expect = expect.clone();
                 }
                 if (snippet.flags.async) {
+
                     var promise = vm.runInThisContext(
-                        '(function () { ' +
-                            snippet.code +
-                            '})();'
+                        transpile('(function () { ' + snippet.code + '})();')
                     );
                     if (!isPromise(promise)) {
                         throw new Error('Async code block did not return a promise or throw\n' + snippet.code);
@@ -54,7 +73,9 @@ module.exports = function (snippets, options, cb) {
                         cb();
                     });
                 } else {
-                    vm.runInThisContext(snippet.code);
+                    vm.runInThisContext(
+                        transpile(snippet.code)
+                    );
                     cb();
                 }
             } catch (e) {

--- a/lib/locateBabelrc.js
+++ b/lib/locateBabelrc.js
@@ -1,0 +1,15 @@
+var pathModule = require('path');
+var fs = require('fs')
+
+module.exports = function locateBabelrc() {
+    var dirFragments = pathModule.dirname(require.main.filename).split(pathModule.sep).slice(1);
+    for (var i = dirFragments.length ; i >= 0 ; i -= 1) {
+        try {
+            var tryBabelRcPath = pathModule.resolve('/' + dirFragments.slice(0, i).join(pathModule.sep), '.babelrc');
+            var stats = fs.statSync(tryBabelRcPath);
+            if (stats.isFile()) {
+              return tryBabelRcPath;
+            }
+        } catch (e) {}
+    }
+};


### PR DESCRIPTION
This PR fixes the final part of #2, it uses babel for transpiling if babel core can be required.