### PR TITLE
Babel transpile before esprima parsing

### DIFF
--- a/lib/UnexpectedMarkdown.js
+++ b/lib/UnexpectedMarkdown.js
@@ -8,18 +8,6 @@ var marked = require('marked-papandreou');
 var fs = require('fs');
 var pathModule = require('path');
 var convertMarkdownToMocha = require('./convertMarkdownToMocha');
-var sourceMap = require('source-map');
-var locateBabelrc = require('./locateBabelrc');
-
-var babelCore;
-var babelOptions;
-try {
-    babelCore = require.main.require('babel-core');
-    var babelrc = locateBabelrc();
-    babelOptions = JSON.parse(fs.readFileSync(babelrc, 'utf-8'));
-} catch (e) {
-    babelCore = null;
-}
 
 var maps = {};
 
@@ -34,46 +22,6 @@ require.extensions['.md'] = function (module, fileName) {
     // module and registers a handler with it:
     var map = sourceMapWithCode.map.toString();
     var code = sourceMapWithCode.code;
-
-    if (babelCore) {
-        var inputSourceMap = JSON.parse(map);
-
-        // Sanitize source map so it's not rejected by babel
-        // (waiting for https://phabricator.babeljs.io/T7151 to be addressed)
-        var inputMapConsumer = new sourceMap.SourceMapConsumer(inputSourceMap);
-        var sourceMapGenerator = new sourceMap.SourceMapGenerator({
-            file: inputMapConsumer.file,
-            sourceRoot: inputMapConsumer.sourceRoot
-        });
-
-        inputMapConsumer.eachMapping(function (mapping) {
-            var generatedPosition = inputMapConsumer.generatedPositionFor({
-                line: mapping.generatedLine,
-                column: mapping.generatedColumn,
-                source: mapping.source
-            });
-            if (mapping.source !== null && generatedPosition.line !== null && mapping.originalLine !== null && mapping.name !== null) {
-                sourceMapGenerator.addMapping({
-                    source: mapping.source,
-                    original: {
-                        line: mapping.originalLine,
-                        column: mapping.originalColumn
-                    },
-                    generated: generatedPosition
-                });
-            }
-        });
-
-        inputSourceMap.file = fileName;
-
-        var babelResult = babelCore.transform(code, extend({}, babelOptions, {
-            sourceMaps: true,
-            compact: false,
-            inputSourceMap: sourceMapGenerator.toJSON()
-        }));
-        code = babelResult.code;
-        map = babelResult.map;
-    }
 
     maps[absoluteFileName] = map;
 

--- a/lib/convertMarkdownToMocha.js
+++ b/lib/convertMarkdownToMocha.js
@@ -3,6 +3,30 @@ var pathModule = require('path');
 var esprima = require('esprima');
 var escodegen = require('escodegen');
 var snippetRegexp = require('./snippetRegexp');
+var locateBabelrc = require('./locateBabelrc');
+var fs = require('fs');
+
+var transpile;
+var hasBabel = false;
+try {
+    var babelCore = require.main.require('babel-core');
+    var babelrc = locateBabelrc();
+    var babelOptions = JSON.parse(fs.readFileSync(babelrc, 'utf-8'));
+    hasBabel = true;
+
+    transpile = function transpile(code) {
+        var babelResult = babelCore.transform(code, extend({}, babelOptions, {
+            sourceMaps: false,
+            compact: false
+        }));
+
+        return babelResult.code.replace(/'use strict';/, '');
+    };
+} catch (e) {
+    transpile = function transpile(code) {
+        return code;
+    };
+}
 
 function extend(target) {
     for (var i = 1; i < arguments.length; i += 1) {
@@ -243,6 +267,23 @@ module.exports = function (mdSrc, fileName) {
 
     describeCall.arguments[0].value = pathModule.basename(fileName, '.md');
 
+    var preamble;
+    if (hasBabel) {
+        var preambleSeparator = '\n//---------------------preamble----------------------\n';
+        var separator = '\n//---------------------separator---------------------\n';
+        var transpiledCode = transpile(preambleSeparator + codeBlocks.map(function (codeBlock) {
+            return codeBlock.code;
+        }).join(separator));
+
+        var transpiledBlocks = transpiledCode.split(new RegExp(preambleSeparator + '|' + separator));
+
+        preamble = esprima.parse(transpiledBlocks[0]);
+
+        transpiledBlocks.slice(1).forEach(function (transpiledBlock, i) {
+            codeBlocks[i].code = transpiledBlock;
+        });
+    }
+
     codeBlocks.forEach(function (codeBlock, i) {
         var exampleNumber = i + 1;
         /* eslint-disable */
@@ -253,6 +294,10 @@ module.exports = function (mdSrc, fileName) {
         })[0];
         /* eslint-enable */
         itExpressionStatement.expression.arguments[0].value = 'example #' + exampleNumber + ' (' + fileName + ':' + (codeBlock.lineNumber + 1) + ':1) should ' + (typeof codeBlock.output === 'string' ? 'fail with the correct error message' : 'succeed');
+
+        if (preamble) {
+            itExpressionStatement.expression.arguments[1].body.body.push(preamble);
+        }
 
         describeCall.arguments[1].body.body.push(itExpressionStatement);
 

--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -7,17 +7,20 @@ var createExpect = require('./createExpect');
 var locateBabelrc = require('./locateBabelrc');
 
 var transpile;
+var hasBabel = false;
 try {
     var babelCore = require.main.require('babel-core');
     var babelrc = locateBabelrc();
     var babelOptions = JSON.parse(fs.readFileSync(babelrc, 'utf-8'));
+    hasBabel = true;
 
     transpile = function transpile(code) {
         var babelResult = babelCore.transform(code, extend({}, babelOptions, {
             sourceMaps: false,
             compact: false
         }));
-        return babelResult.code;
+
+        return babelResult.code.replace(/'use strict';/, '');
     };
 } catch (e) {
     transpile = function transpile(code) {
@@ -52,16 +55,40 @@ module.exports = function (snippets, options, cb) {
     global.expect = expect.clone();
     global.require = require;
 
+    if (hasBabel) {
+        var preambleSeparator = '\n//---------------------preamble----------------------\n';
+        var separator = '\n//---------------------separator---------------------\n';
+
+        var exampleSnippets = snippets.filter(function (snippet) {
+            return snippet.lang === 'javascript' && snippet.flags.evaluate;
+        });
+
+        var codeForTranspilation = preambleSeparator + exampleSnippets.map(function (snippet) {
+            return snippet.code;
+        }).join(separator);
+
+        var transpiledCode = transpile(codeForTranspilation);
+        var transpiledSnippets = transpiledCode.split(new RegExp(preambleSeparator + '|' + separator));
+
+        var preamble = transpiledSnippets[0];
+        vm.runInThisContext(preamble);
+
+        transpiledSnippets.slice(1).forEach(function (transpiledSnippet, i) {
+            exampleSnippets[i].code = transpiledSnippet;
+        });
+    }
+
     async.eachSeries(snippets, function (snippet, cb) {
         if (snippet.lang === 'javascript' && snippet.flags.evaluate) {
             try {
                 if (snippet.flags.freshExpect) {
                     global.expect = expect.clone();
                 }
-                var transpiledCode;
+
                 if (snippet.flags.async) {
-                    transpiledCode = transpile('(function () { ' + snippet.code + '})();');
-                    var promise = vm.runInThisContext(transpiledCode);
+                    var promise = vm.runInThisContext(
+                        '(function () {' + snippet.code + '})();'
+                    );
                     if (!isPromise(promise)) {
                         throw new Error('Async code block did not return a promise or throw\n' + snippet.code);
                     }
@@ -73,8 +100,7 @@ module.exports = function (snippets, options, cb) {
                         cb();
                     });
                 } else {
-                    transpiledCode = transpile(snippet.code);
-                    vm.runInThisContext(transpiledCode);
+                    vm.runInThisContext(snippet.code);
                     cb();
                 }
             } catch (e) {


### PR DESCRIPTION
Our current Babel transpiling doesn't really work as definitions can be used across examples. Babel needs all the code to as it mangles the variables and other weird stuff. This PR transpiles everything in a markdown file at once and split the examples up again. It is a bit hacky but it works. 

I would really like this change to be merged as it would enable unexpected-react to evaluate the example in the documentation and the current implementation is incorrect.

If you don't use Babel you shouldn't be affected by this change at all.

cc: @papandreou  