### PR TITLE
Allow code block modifiers/flags in HTML comments

### DIFF
--- a/lib/UnexpectedMarkdown.js
+++ b/lib/UnexpectedMarkdown.js
@@ -124,7 +124,12 @@ UnexpectedMarkdown.prototype.withUpdatedExamples = function(options, cb) {
     options,
     passError(cb, function(snippets) {
       var index = 0;
-      var updateContent = content.replace(snippetRegexp, function($0, lang) {
+      var updateContent = content.replace(snippetRegexp, function(
+        $0,
+        htmlComment,
+        htmlCommentFlags,
+        lang
+      ) {
         var currentIndex = index;
         index += 1;
         var snippet = snippets.get(currentIndex);
@@ -136,7 +141,7 @@ UnexpectedMarkdown.prototype.withUpdatedExamples = function(options, cb) {
               output = example.errorMessage;
             }
           }
-          return '```' + lang + '\n' + output + '\n```';
+          return (htmlComment || '') + '```' + lang + '\n' + output + '\n```';
         } else {
           return $0;
         }

--- a/lib/convertMarkdownToMocha.js
+++ b/lib/convertMarkdownToMocha.js
@@ -2,7 +2,7 @@
 var pathModule = require('path');
 var esprima = require('esprima');
 var escodegen = require('escodegen');
-var snippetRegexp = require('./snippetRegexp');
+var extractSnippets = require('./extractSnippets');
 var locateBabelrc = require('./locateBabelrc');
 var fs = require('fs');
 
@@ -39,33 +39,6 @@ function extend(target) {
     });
   }
   return target;
-}
-
-function parseBlockInfo(lang) {
-  var m = /^(\w+)#(\w+:\w+(,\w+:\w+)*)/.exec(lang);
-  var flags = { evaluate: true };
-  if (m) {
-    lang = m[1];
-    extend(flags, parseFlags(m[2]));
-  }
-
-  if (lang === 'js') {
-    lang = 'javascript';
-  }
-
-  return {
-    lang: lang,
-    flags: flags
-  };
-}
-
-function parseFlags(flagsString) {
-  var flags = {};
-  flagsString.split(/,/).forEach(function(flagString) {
-    var m = /(\w+):(\w+)/.exec(flagString);
-    flags[m[1]] = m[2] === 'true';
-  });
-  return flags;
 }
 
 function parseFunctionBody(fn) {
@@ -163,13 +136,9 @@ function countLinesUntilIndex(text, untilIndex) {
 }
 
 function findCodeBlocks(mdSrc) {
-  snippetRegexp.lastIndex = 0;
   var codeBlocks = [];
-  var matchCodeBlock;
-  while ((matchCodeBlock = snippetRegexp.exec(mdSrc))) {
-    var codeBlock = parseBlockInfo(matchCodeBlock[1]);
-    codeBlock.code = matchCodeBlock[2];
-    codeBlock.index = matchCodeBlock.index;
+  const snippets = extractSnippets(mdSrc);
+  for (const codeBlock of snippets) {
     codeBlock.lineNumber = 1 + countLinesUntilIndex(mdSrc, codeBlock.index);
     if (codeBlock.lang === 'output') {
       var lastJavaScriptBlock = codeBlocks[codeBlocks.length - 1];

--- a/lib/extractSnippets.js
+++ b/lib/extractSnippets.js
@@ -4,7 +4,7 @@ var extend = require('./extend');
 function parseFlags(flagsString) {
   var flags = {};
   flagsString.split(/,/).forEach(function(flagString) {
-    var m = /(\w+):(\w+)/.exec(flagString);
+    var m = /(\w+)\s*:\s*(\w+)/.exec(flagString.trim());
     flags[m[1]] = m[2] === 'true';
   });
   return flags;
@@ -12,7 +12,7 @@ function parseFlags(flagsString) {
 
 function parseSnippetInfo(lang) {
   var m = /^(\w+)#(\w+:\w+(,\w+:\w+)*)/.exec(lang);
-  var flags = { evaluate: true };
+  var flags = {};
   if (m) {
     lang = m[1];
     extend(flags, parseFlags(m[2]));
@@ -32,8 +32,16 @@ module.exports = function(markdown) {
   var snippets = [];
   var m;
   while ((m = snippetRegexp.exec(markdown))) {
-    var snippetInfo = parseSnippetInfo(m[1]);
-    snippetInfo.code = m[2];
+    var snippetInfo = parseSnippetInfo(m[3]);
+    snippetInfo.index = m.index;
+    if (m[2]) {
+      snippetInfo.index += m[1].length;
+      snippetInfo.flags = Object.assign(parseFlags(m[2]), snippetInfo.flags);
+    }
+    if (typeof snippetInfo.flags.evaluate !== 'boolean') {
+      snippetInfo.flags.evaluate = true;
+    }
+    snippetInfo.code = m[4];
     snippets.push(snippetInfo);
   }
   return snippets;

--- a/lib/snippetRegexp.js
+++ b/lib/snippetRegexp.js
@@ -1,1 +1,1 @@
-module.exports = /^```(\S*)\n([\s\S]*?)\n```/gm;
+module.exports = /(^<!--([^\n]+)-->\n)?^```(\S*)\n([\s\S]*?)\n```/gm;

--- a/test/extractSnippets.js
+++ b/test/extractSnippets.js
@@ -28,6 +28,30 @@ describe('extractSnippets', function() {
     ]);
   });
 
+  it('should default to evaluate:true', function() {
+    expect(extractSnippets('```js\nalert("Hello!");\n```\n'), 'to satisfy', [
+      { flags: { evaluate: true } }
+    ]);
+  });
+
+  it('should allow changing evaluate to false via js#evaluate:false', function() {
+    expect(
+      extractSnippets('```js#evaluate:false\nalert("Hello!");\n```\n'),
+      'to satisfy',
+      [{ flags: { evaluate: false } }]
+    );
+  });
+
+  it('should allow changing evaluate to false via a preceding HTML comment', function() {
+    expect(
+      extractSnippets(
+        '<!-- evaluate:false -->\n```js\nalert("Hello!");\n```\n'
+      ),
+      'to satisfy',
+      [{ flags: { evaluate: false } }]
+    );
+  });
+
   it('should extract a flag after the language specifier and #', function() {
     expect(
       extractSnippets('```js#foo:true\nalert("Hello!");\n```\n'),
@@ -41,6 +65,72 @@ describe('extractSnippets', function() {
       extractSnippets('```js#foo:true,bar:false\nalert("Hello!");\n```\n'),
       'to satisfy',
       [{ flags: { foo: true, bar: false } }]
+    );
+  });
+
+  it('should extract a flag from a preceding HTML comment', function() {
+    expect(
+      extractSnippets('<!-- foo:true -->\n```js\nalert("Hello!");\n```\n'),
+      'to satisfy',
+      [{ flags: { foo: true } }]
+    );
+  });
+
+  it('should extract multiple comma-separated flags from a preceding HTML comment', function() {
+    expect(
+      extractSnippets(
+        '<!-- foo:true,bar:false -->\n```js\nalert("Hello!");\n```\n'
+      ),
+      'to satisfy',
+      [{ flags: { foo: true, bar: false } }]
+    );
+  });
+
+  it('should tolerate whitespace between the flags and commans in the preceding HTML comment', function() {
+    expect(
+      extractSnippets(
+        '<!-- foo : true , bar : false -->\n```js\nalert("Hello!");\n```\n'
+      ),
+      'to satisfy',
+      [{ flags: { foo: true, bar: false } }]
+    );
+  });
+
+  it('should extract flags from both a preceding HTML command and after the language specifier and #', function() {
+    expect(
+      extractSnippets(
+        '<!-- foo:true -->\n```js#bar:false\nalert("Hello!");\n```\n'
+      ),
+      'to satisfy',
+      [{ flags: { foo: true, bar: false } }]
+    );
+  });
+
+  it('should let the flags after the language specifier win when the same flag is provided in both places', function() {
+    expect(
+      extractSnippets(
+        '<!-- foo:true -->\n```js#foo:false\nalert("Hello!");\n```\n'
+      ),
+      'to satisfy',
+      [{ flags: { foo: false } }]
+    );
+  });
+
+  it('provides the index of the block', function() {
+    expect(
+      extractSnippets('foobar\n```js#foo:false\nalert("Hello!");\n```\n'),
+      'to satisfy',
+      [{ index: 7 }]
+    );
+  });
+
+  it('skips past a preceding HTML comment when providing the index', function() {
+    expect(
+      extractSnippets(
+        'foobar\n<!-- foo: bar -->\n```js#foo:false\nalert("Hello!");\n```\n'
+      ),
+      'to satisfy',
+      [{ index: 25 }]
     );
   });
 });


### PR DESCRIPTION
Fixes #12

Also reduce duplication by using extractSnippets in convertMarkdownToMocha