### PR TITLE
Add the ability for output blocks to specify a cleanStackTrace flag

### DIFF
--- a/lib/UnexpectedMarkdown.js
+++ b/lib/UnexpectedMarkdown.js
@@ -7,6 +7,7 @@ var marked = require('marked-papandreou');
 var fs = require('fs');
 var pathModule = require('path');
 var convertMarkdownToMocha = require('./convertMarkdownToMocha');
+var cleanStackTrace = require('./cleanStackTrace');
 
 var maps = {};
 
@@ -138,6 +139,9 @@ UnexpectedMarkdown.prototype.withUpdatedExamples = function(options, cb) {
           if (example && example.lang === 'javascript') {
             if (example.errorMessage) {
               output = example.errorMessage;
+              if (snippet.flags.cleanStackTrace) {
+                output = cleanStackTrace(output);
+              }
             }
           }
           return `${htmlComments || ''}\`\`\`${lang}\n${output}\n\`\`\``;

--- a/lib/cleanStackTrace.js
+++ b/lib/cleanStackTrace.js
@@ -1,0 +1,24 @@
+function cleanStackTrace(stack) {
+  // Mangle a stack trace so that it doesn't contain file names and line numbers,
+  // as that would make a test very fragile:
+  var lines = stack.split('\n');
+  let numStackLines = 0;
+  for (var i = 0; i < lines.length; i += 1) {
+    const matchStackLine = lines[i].match(/^( +at \w+) \([^)]+\)/);
+    if (matchStackLine) {
+      numStackLines += 1;
+      if (numStackLines <= 2) {
+        // eslint-disable-next-line prefer-template
+        lines[i] = matchStackLine[1] + ' (/path/to/file.js:x:y)';
+      } else {
+        lines.splice(i, 1);
+        i -= 1;
+      }
+    } else {
+      numStackLines = 0;
+    }
+  }
+  return lines.join('\n');
+}
+
+module.exports = cleanStackTrace;

--- a/lib/convertMarkdownToMocha.js
+++ b/lib/convertMarkdownToMocha.js
@@ -5,6 +5,7 @@ var escodegen = require('escodegen');
 var extractSnippets = require('./extractSnippets');
 var locateBabelrc = require('./locateBabelrc');
 var fs = require('fs');
+var cleanStackTrace = require('./cleanStackTrace');
 
 var transpile;
 var hasBabel = false;
@@ -141,6 +142,7 @@ function findCodeBlocks(mdSrc) {
         throw new Error('output block must follow code block');
       }
       lastJavaScriptBlock.output = codeBlock.code;
+      lastJavaScriptBlock.outputFlags = codeBlock.flags || {};
     } else if (codeBlock.lang === 'javascript' && codeBlock.flags.evaluate) {
       codeBlocks.push(codeBlock);
     }
@@ -205,13 +207,44 @@ function compileCodeBlocksToAst(codeBlocks, fileName) {
       if (typeof codeBlock.output === 'string') {
         check = parseFunctionBody(function f(err, expect) {
           if (err) {
-            expect(err, 'to have message', 'expectedErrorMessage');
+            var message = err.isUnexpected
+              ? err.getErrorMessage('text').toString()
+              : err.message;
+
+            expect(message, 'to equal', 'expectedErrorMessage');
           } else {
-            throw new Error('expected example 1 to fail');
+            throw new Error('expected example to fail');
           }
         });
-        check[0].consequent.body[0].expression.arguments[2].value =
+        check[0].consequent.body[1].expression.arguments[2].value =
           codeBlock.output;
+        if (codeBlock.outputFlags.cleanStackTrace) {
+          check[0].consequent.body.splice(1, 0, {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'AssignmentExpression',
+              operator: '=',
+              left: {
+                type: 'Identifier',
+                name: 'message'
+              },
+              right: {
+                type: 'CallExpression',
+                callee: {
+                  type: 'Identifier',
+                  name: 'cleanStackTrace'
+                },
+                arguments: [
+                  {
+                    type: 'Identifier',
+                    name: 'message'
+                  }
+                ]
+              }
+            }
+          });
+          check.unshift(esprima.parse(cleanStackTrace.toString()).body[0]);
+        }
       } else {
         check = parseFunctionBody(function f(err, expect) {
           if (err) {

--- a/test/UnexpectedMarkdown.spec.js
+++ b/test/UnexpectedMarkdown.spec.js
@@ -64,22 +64,17 @@ describe('UnexpectedMarkdown', function() {
   });
 
   describe('withUpdatedExamples', function() {
-    var updatedMarkdownPromise;
-    beforeEach(function() {
-      updatedMarkdownPromise = expect.promise(function(resolve, reject) {
-        markdown.withUpdatedExamples({}, function(err, markdown) {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(markdown.toString());
-          }
-        });
-      });
-    });
-
     it('produces a markdown where the examples has been updated', function() {
       return expect(
-        updatedMarkdownPromise,
+        expect.promise(function(resolve, reject) {
+          markdown.withUpdatedExamples({}, function(err, markdown) {
+            if (err) {
+              reject(err);
+            } else {
+              resolve(markdown.toString());
+            }
+          });
+        }),
         'when fulfilled',
         'to contain',
         [
@@ -96,5 +91,44 @@ describe('UnexpectedMarkdown', function() {
         ].join('\n')
       );
     });
+  });
+
+  it('produces a markdown where the examples has been updated', function() {
+    const markdown = new UnexpectedMarkdown(
+      [
+        'Asserts deep equality.',
+        '',
+        '```javascript',
+        'throw new Error("foo\\n  at bar (/somewhere.js:1:2)\\n  at quux (/blah.js:3:4)\\n  at baz (/yadda.js:5:6)")',
+        '```',
+        '',
+        '<!-- unexpected-markdown cleanStackTrace:true -->',
+        '```output',
+        'Missing output',
+        '```'
+      ].join('\n')
+    );
+
+    return expect(
+      expect.promise(function(resolve, reject) {
+        markdown.withUpdatedExamples({}, function(err, markdown) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(markdown.toString());
+          }
+        });
+      }),
+      'when fulfilled',
+      'to contain',
+      [
+        '<!-- unexpected-markdown cleanStackTrace:true -->',
+        '```output',
+        'foo',
+        '  at bar (/path/to/file.js:x:y)',
+        '  at quux (/path/to/file.js:x:y)',
+        '```'
+      ].join('\n')
+    );
   });
 });

--- a/test/cleanStackTrace.js
+++ b/test/cleanStackTrace.js
@@ -1,0 +1,42 @@
+const expect = require('unexpected');
+const cleanStackTrace = require('../lib/cleanStackTrace');
+
+describe('cleanStackTrace', function() {
+  it('should turn line numbers into :x:y', function() {
+    expect(
+      cleanStackTrace('foo\n  at bar (/somewhere.js:1:2)'),
+      'to contain',
+      ':x:y'
+    );
+  });
+
+  it('should only preserve 2 stack locations per trace', function() {
+    expect(
+      cleanStackTrace(
+        [
+          'foo',
+          '  at bar (/a.js:1:2)',
+          '  at baz (/a.js:1:2)',
+          '  at quux (/a.js:1:2)',
+          'something else',
+          'foo',
+          '  at bar (/a.js:1:2)',
+          '  at baz (/a.js:1:2)',
+          '  at quux (/a.js:1:2)',
+          'hey'
+        ].join('\n')
+      ),
+      'to equal',
+      [
+        'foo',
+        '  at bar (/path/to/file.js:x:y)',
+        '  at baz (/path/to/file.js:x:y)',
+        'something else',
+        'foo',
+        '  at bar (/path/to/file.js:x:y)',
+        '  at baz (/path/to/file.js:x:y)',
+        'hey'
+      ].join('\n')
+    );
+  });
+});

--- a/test/convertMarkdownToMocha.js
+++ b/test/convertMarkdownToMocha.js
@@ -144,9 +144,95 @@ describe('convertMarkdownToMocha', function() {
             }
             function endOfExample1(err) {
               if (err) {
-                expect(err, 'to have message', 'theErrorMessage');
+                var message = err.isUnexpected
+                  ? err.getErrorMessage('text').toString()
+                  : err.message;
+                expect(message, 'to equal', 'theErrorMessage');
               } else {
-                throw new Error('expected example 1 to fail');
+                throw new Error('expected example to fail');
+              }
+            }
+          });
+        });
+      }
+    );
+  });
+
+  it('should convert a snippet where the output block has cleanStackTrace:true', function() {
+    expect(
+      `${fences(
+        returningSuccessfulSnippet
+      )}\n<!-- unexpected-markdown cleanStackTrace:true -->\n${fences(
+        'theErrorMessage',
+        'output'
+      )}`,
+      'to come out as',
+      function() {
+        function isPromise(obj) {
+          return obj && typeof obj.then === 'function';
+        }
+
+        if (typeof unexpected === 'undefined') {
+          unexpected = require('unexpected');
+          unexpected.output.preferredWidth = 80;
+        }
+
+        describe('<inline code>', function() {
+          it('example #1 (<inline code>:2:1) should fail with the correct error message', function() {
+            var expect = unexpected.clone();
+            var __returnValue1;
+            example1: try {
+              var blah = 'abc';
+              if (blah === 'abc') {
+                __returnValue1 = expect.promise(function(resolve, reject) {
+                  setImmediate(resolve);
+                });
+                break example1;
+              } else {
+                __returnValue1 = 456;
+                break example1;
+              }
+            } catch (err) {
+              return endOfExample1(err);
+            }
+            if (isPromise(__returnValue1)) {
+              return __returnValue1.then(function() {
+                return endOfExample1();
+              }, endOfExample1);
+            } else {
+              return endOfExample1();
+            }
+            function endOfExample1(err) {
+              function cleanStackTrace(stack) {
+                var lines = stack.split('\n');
+                let numStackLines = 0;
+                for (var i = 0; i < lines.length; i += 1) {
+                  const matchStackLine = lines[i].match(
+                    /^( +at \w+) \([^)]+\)/
+                  );
+                  if (matchStackLine) {
+                    numStackLines += 1;
+                    if (numStackLines <= 2) {
+                      // eslint-disable-next-line prefer-template
+                      lines[i] = matchStackLine[1] + ' (/path/to/file.js:x:y)';
+                    } else {
+                      lines.splice(i, 1);
+                      i -= 1;
+                    }
+                  } else {
+                    numStackLines = 0;
+                  }
+                }
+                return lines.join('\n');
+              }
+              if (err) {
+                var message = err.isUnexpected
+                  ? err.getErrorMessage('text').toString()
+                  : err.message;
+                message = cleanStackTrace(message);
+                expect(message, 'to equal', 'theErrorMessage');
+              } else {
+                throw new Error('expected example to fail');
               }
             }
           });
@@ -199,9 +285,12 @@ describe('convertMarkdownToMocha', function() {
             }
             function endOfExample1(err) {
               if (err) {
-                expect(err, 'to have message', 'theErrorMessage');
+                var message = err.isUnexpected
+                  ? err.getErrorMessage('text').toString()
+                  : err.message;
+                expect(message, 'to equal', 'theErrorMessage');
               } else {
-                throw new Error('expected example 1 to fail');
+                throw new Error('expected example to fail');
               }
             }
           });
@@ -332,9 +421,12 @@ describe('convertMarkdownToMocha', function() {
             }
             function endOfExample1(err) {
               if (err) {
-                expect(err, 'to have message', 'theErrorMessage');
+                var message = err.isUnexpected
+                  ? err.getErrorMessage('text').toString()
+                  : err.message;
+                expect(message, 'to equal', 'theErrorMessage');
               } else {
-                throw new Error('expected example 1 to fail');
+                throw new Error('expected example to fail');
               }
             }
           });
@@ -379,9 +471,12 @@ describe('convertMarkdownToMocha', function() {
             }
             function endOfExample1(err) {
               if (err) {
-                expect(err, 'to have message', 'theErrorMessage');
+                var message = err.isUnexpected
+                  ? err.getErrorMessage('text').toString()
+                  : err.message;
+                expect(message, 'to equal', 'theErrorMessage');
               } else {
-                throw new Error('expected example 1 to fail');
+                throw new Error('expected example to fail');
               }
             }
           });

--- a/test/extractSnippets.js
+++ b/test/extractSnippets.js
@@ -155,4 +155,14 @@ describe('extractSnippets', function() {
       [{ index: 25 }]
     );
   });
+
+  it('captures flag before output blocks', function() {
+    expect(
+      extractSnippets(
+        '```js\nalert("Hello!");\n```\n\n<!-- unexpected-markdown foo:true -->\n```output\nthe output\n```\n'
+      ),
+      'to satisfy',
+      [{ lang: 'javascript' }, { lang: 'output', flags: { foo: true } }]
+    );
+  });
 });


### PR DESCRIPTION
I'm trying to find a way to prevent expected error messages in documentation tests from ending up containing fragile locale paths and line numbers: https://github.com/unexpectedjs/unexpected-check/pull/72/files#diff-427e19127578e2ecfb543075bbce8e9dR71-R114

Seems like something that unexpected-markdown can handle via a flag. What do you think, @sunesimonsen?