### PR TITLE
Rejection from promises

### DIFF
--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -28,11 +28,7 @@ try {
 }
 
 function isPromise(value) {
-  return (
-    value &&
-    typeof value.then === 'function' &&
-    typeof value.caught === 'function'
-  );
+  return value && typeof value.then === 'function';
 }
 
 function getErrorMessage(expect, format, error) {
@@ -110,6 +106,7 @@ module.exports = async function(snippets, options) {
               ? snippet.code
               : `(function () {${transpile(snippet.code)}})();`
           );
+
           if (!isPromise(promise)) {
             throw new Error(
               `Async code block did not return a promise or throw\n${snippet.code}`

--- a/test/UnexpectedMarkdown.spec.js
+++ b/test/UnexpectedMarkdown.spec.js
@@ -75,6 +75,29 @@ describe('UnexpectedMarkdown', function() {
         )
       );
     });
+
+    it('should work correctly with async snippets that reject', async () => {
+      const markdown = new UnexpectedMarkdown(
+        [
+          '<!-- unexpected-markdown async:true -->',
+          '```javascript',
+          "return Promise.reject(new Error('boom'));",
+          '```',
+          '',
+          '```output',
+          'Missing output',
+          '```'
+        ].join('\n')
+      );
+
+      const updatedMarkdown = await markdown.withUpdatedExamples({});
+
+      expect(
+        updatedMarkdown.content,
+        'to contain',
+        ['```output', 'boom', '```'].join('\n')
+      );
+    });
   });
 
   it('produces a markdown where the examples has been updated', function() {


### PR DESCRIPTION
The promise check was a little too narrow allowing only Unexpected promises. Make this work with standard promises now that await will handle unpacking them.