### PR TITLE
Execute in new context

### DIFF
--- a/lib/UnexpectedMarkdown.js
+++ b/lib/UnexpectedMarkdown.js
@@ -58,7 +58,6 @@ class UnexpectedMarkdown {
 
   async toHtml(options) {
     var content = this.content;
-    var expect = createExpect(options);
 
     const snippets = await this.getSnippets(options);
 
@@ -86,7 +85,14 @@ class UnexpectedMarkdown {
         }
       }
 
-      return expect.output
+      let output;
+      if (options.theme) {
+        output = createExpect(options).output;
+      } else {
+        output = createExpect({ ...options, theme: 'notheme' }).output;
+      }
+
+      return output
         .clone('html')
         .code(code, lang)
         .toString()

--- a/lib/UnexpectedMarkdown.js
+++ b/lib/UnexpectedMarkdown.js
@@ -57,6 +57,8 @@ class UnexpectedMarkdown {
   }
 
   async toHtml(options) {
+    options = { ...options };
+
     var content = this.content;
 
     const snippets = await this.getSnippets(options);
@@ -111,6 +113,8 @@ class UnexpectedMarkdown {
   }
 
   async withUpdatedExamples(options) {
+    options = { ...options };
+
     const snippets = await this.getSnippets(options);
 
     var index = 0;

--- a/lib/createExpect.js
+++ b/lib/createExpect.js
@@ -20,10 +20,14 @@ module.exports = function(options) {
   }
   expect.installPlugin(require('magicpen-prism'));
 
-  var themePlugin =
-    options.theme === 'dark'
-      ? require('./magicpenDarkSyntaxTheme')
-      : require('./magicpenGithubSyntaxTheme');
+  if (options.theme !== 'notheme') {
+    var themePlugin =
+      options.theme === 'dark'
+        ? require('./magicpenDarkSyntaxTheme')
+        : require('./magicpenGithubSyntaxTheme');
 
-  return expect.installPlugin(themePlugin);
+    expect.installPlugin(themePlugin);
+  }
+
+  return expect;
 };

--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -53,7 +53,6 @@ function getErrorMessage(expect, format, error) {
 }
 
 module.exports = async function(snippets, options) {
-  var oldGlobal = Object.assign({}, global);
   const baseExpect = createExpect({ ...options, theme: 'notheme' });
 
   const context = {};
@@ -150,16 +149,5 @@ module.exports = async function(snippets, options) {
         snippet.errorMessage = getErrorMessage(baseExpect, 'text', e);
       }
     }
-  }
-
-  for (const key of Object.keys(global)) {
-    if (!(key in oldGlobal)) {
-      delete global[key];
-    }
-  }
-
-  // inline function used for compatibility with node 8
-  for (const key of Object.keys(oldGlobal)) {
-    global[key] = oldGlobal[key];
   }
 };

--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -55,22 +55,22 @@ function getErrorMessage(expect, format, error) {
 module.exports = async function(snippets, options) {
   const baseExpect = createExpect({ ...options, theme: 'notheme' });
 
-  const context = {};
+  const sandbox = {};
   for (const [variable, createVariable] of Object.entries(
     (options && options.globals) || {}
   )) {
-    context[variable] = createVariable(options);
+    sandbox[variable] = createVariable(options);
   }
-  context.require = require;
-  if (!Object.prototype.hasOwnProperty.call(context, 'expect')) {
-    context.expect = createExpect(options);
+  sandbox.require = require;
+  if (!Object.prototype.hasOwnProperty.call(sandbox, 'expect')) {
+    sandbox.expect = createExpect(options);
   }
 
   // grab a reference before any modifications are done to it
   let testExpect;
-  if (context.expect && context.expect._topLevelExpect) {
-    testExpect = context.expect;
-    context.expect = context.expect.clone();
+  if (sandbox.expect && sandbox.expect._topLevelExpect) {
+    testExpect = sandbox.expect;
+    sandbox.expect = sandbox.expect.clone();
   } else {
     testExpect = null;
   }
@@ -103,7 +103,7 @@ module.exports = async function(snippets, options) {
       var preamble = transpiledSnippets[0];
       const remainingSnippets = transpiledSnippets.slice(1);
 
-      vm.runInNewContext(preamble, context);
+      vm.runInNewContext(preamble, sandbox);
 
       for (const [i, transpiledSnippet] of remainingSnippets.entries()) {
         exampleSnippets[i].code = transpiledSnippet;
@@ -120,7 +120,7 @@ module.exports = async function(snippets, options) {
               'cannot clone with missing or invalid expect global for freshExpect'
             );
           }
-          context.expect = testExpect.clone();
+          sandbox.expect = testExpect.clone();
         }
 
         if (snippet.flags.async) {
@@ -128,7 +128,7 @@ module.exports = async function(snippets, options) {
             hasBabel
               ? snippet.code
               : `(function () {${transpile(snippet.code)}})();`,
-            context
+            sandbox
           );
 
           if (!isPromise(promise)) {
@@ -141,7 +141,7 @@ module.exports = async function(snippets, options) {
         } else {
           vm.runInNewContext(
             hasBabel ? snippet.code : transpile(snippet.code),
-            context
+            sandbox
           );
         }
       } catch (e) {

--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -56,21 +56,22 @@ module.exports = async function(snippets, options) {
   var oldGlobal = Object.assign({}, global);
   const baseExpect = createExpect({ ...options, theme: 'notheme' });
 
+  const context = {};
   for (const [variable, createVariable] of Object.entries(
     (options && options.globals) || {}
   )) {
-    global[variable] = createVariable(options);
+    context[variable] = createVariable(options);
   }
-  global.require = require;
-  if (!Object.prototype.hasOwnProperty.call(global, 'expect')) {
-    global.expect = createExpect(options);
+  context.require = require;
+  if (!Object.prototype.hasOwnProperty.call(context, 'expect')) {
+    context.expect = createExpect(options);
   }
 
   // grab a reference before any modifications are done to it
   let testExpect;
-  if (global.expect && global.expect._topLevelExpect) {
-    testExpect = global.expect;
-    global.expect = global.expect.clone();
+  if (context.expect && context.expect._topLevelExpect) {
+    testExpect = context.expect;
+    context.expect = context.expect.clone();
   } else {
     testExpect = null;
   }
@@ -103,7 +104,7 @@ module.exports = async function(snippets, options) {
       var preamble = transpiledSnippets[0];
       const remainingSnippets = transpiledSnippets.slice(1);
 
-      vm.runInThisContext(preamble);
+      vm.runInNewContext(preamble, context);
 
       for (const [i, transpiledSnippet] of remainingSnippets.entries()) {
         exampleSnippets[i].code = transpiledSnippet;
@@ -120,14 +121,15 @@ module.exports = async function(snippets, options) {
               'cannot clone with missing or invalid expect global for freshExpect'
             );
           }
-          global.expect = testExpect.clone();
+          context.expect = testExpect.clone();
         }
 
         if (snippet.flags.async) {
-          var promise = vm.runInThisContext(
+          var promise = vm.runInNewContext(
             hasBabel
               ? snippet.code
-              : `(function () {${transpile(snippet.code)}})();`
+              : `(function () {${transpile(snippet.code)}})();`,
+            context
           );
 
           if (!isPromise(promise)) {
@@ -138,8 +140,9 @@ module.exports = async function(snippets, options) {
 
           await promise;
         } else {
-          vm.runInThisContext(
-            hasBabel ? snippet.code : transpile(snippet.code)
+          vm.runInNewContext(
+            hasBabel ? snippet.code : transpile(snippet.code),
+            context
           );
         }
       } catch (e) {

--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -56,9 +56,24 @@ module.exports = async function(snippets, options) {
   var oldGlobal = Object.assign({}, global);
   const baseExpect = createExpect({ ...options, theme: 'notheme' });
 
-  const testExpect = createExpect(options);
-  global.expect = testExpect.clone();
+  for (const [variable, createVariable] of Object.entries(
+    (options && options.globals) || {}
+  )) {
+    global[variable] = createVariable(options);
+  }
   global.require = require;
+  if (!Object.prototype.hasOwnProperty.call(global, 'expect')) {
+    global.expect = createExpect(options);
+  }
+
+  // grab a reference before any modifications are done to it
+  let testExpect;
+  if (global.expect && global.expect._topLevelExpect) {
+    testExpect = global.expect;
+    global.expect = global.expect.clone();
+  } else {
+    testExpect = null;
+  }
 
   if (hasBabel) {
     var preambleSeparator =
@@ -100,6 +115,11 @@ module.exports = async function(snippets, options) {
     if (snippet.lang === 'javascript' && snippet.flags.evaluate) {
       try {
         if (snippet.flags.freshExpect) {
+          if (!testExpect) {
+            throw new Error(
+              'cannot clone with missing or invalid expect global for freshExpect'
+            );
+          }
           global.expect = testExpect.clone();
         }
 

--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -54,8 +54,10 @@ function getErrorMessage(expect, format, error) {
 
 module.exports = async function(snippets, options) {
   var oldGlobal = Object.assign({}, global);
-  var expect = createExpect(options);
-  global.expect = expect.clone();
+  const baseExpect = createExpect({ ...options, theme: 'notheme' });
+
+  const testExpect = createExpect(options);
+  global.expect = testExpect.clone();
   global.require = require;
 
   if (hasBabel) {
@@ -98,7 +100,7 @@ module.exports = async function(snippets, options) {
     if (snippet.lang === 'javascript' && snippet.flags.evaluate) {
       try {
         if (snippet.flags.freshExpect) {
-          global.expect = expect.clone();
+          global.expect = testExpect.clone();
         }
 
         if (snippet.flags.async) {
@@ -121,8 +123,8 @@ module.exports = async function(snippets, options) {
           );
         }
       } catch (e) {
-        snippet.htmlErrorMessage = getErrorMessage(global.expect, 'html', e);
-        snippet.errorMessage = getErrorMessage(global.expect, 'text', e);
+        snippet.htmlErrorMessage = getErrorMessage(baseExpect, 'html', e);
+        snippet.errorMessage = getErrorMessage(baseExpect, 'text', e);
       }
     }
   }

--- a/test/evaluateSnippets.spec.js
+++ b/test/evaluateSnippets.spec.js
@@ -113,4 +113,51 @@ describe('extractSnippets', () => {
       errorMessage: 'expected >>bar<< to foo\n\n-bar\n+foo'
     });
   });
+
+  describe('with custom globals', () => {
+    it('should allow specifying additional globals into evaluation', async () => {
+      const snippets = [
+        {
+          lang: 'javascript',
+          flags: { async: true, evaluate: true },
+          index: 40,
+          code: "aliasedExpect(1, 'to equal', 2);"
+        }
+      ];
+
+      await evaluateSnippets(snippets, {
+        globals: {
+          aliasedExpect: () => expect.clone()
+        }
+      });
+
+      expect(snippets[0], 'to satisfy', {
+        htmlErrorMessage:
+          '<div style="font-family: monospace; white-space: nowrap"><div><span style="color: red; font-weight: bold">expected</span>&nbsp;<span style="color: #0086b3">1</span>&nbsp;<span style="color: red; font-weight: bold">to&nbsp;equal</span>&nbsp;<span style="color: #0086b3">2</span></div></div>',
+        errorMessage: 'expected 1 to equal 2'
+      });
+    });
+
+    it('should error on freshExpect if the expect global is not Unexpected', async () => {
+      const snippets = [
+        {
+          lang: 'javascript',
+          flags: { async: true, evaluate: true, freshExpect: true },
+          index: 40,
+          code: "aliasedExpect(1, 'to equal', 2);"
+        }
+      ];
+
+      await evaluateSnippets(snippets, {
+        globals: {
+          expect: () => null
+        }
+      });
+
+      expect(snippets[0], 'to satisfy', {
+        errorMessage:
+          'cannot clone with missing or invalid expect global for freshExpect'
+      });
+    });
+  });
 });

--- a/test/evaluateSnippets.spec.js
+++ b/test/evaluateSnippets.spec.js
@@ -114,8 +114,8 @@ describe('extractSnippets', () => {
     });
   });
 
-  describe('with custom globals', () => {
-    it('should allow specifying additional globals into evaluation', async () => {
+  describe('with custom sandbox', () => {
+    it('should allow specifying additional globals', async () => {
       const snippets = [
         {
           lang: 'javascript',


### PR DESCRIPTION
The changes appear to run tests in a next context. I've rejigged things to allow specifying globals and an object of functions that can create them - this means that the theming for each test continues to work.