### PR TITLE
Use the output from the expect of the UnexpectedError instead of the top-level one

### DIFF
--- a/lib/evaluateSnippets.js
+++ b/lib/evaluateSnippets.js
@@ -34,9 +34,10 @@ function isPromise(value) {
 function getErrorMessage(expect, format, error) {
   if (error) {
     if (error.getErrorMessage) {
-      var output = expect.createOutput
-        ? expect.createOutput(format)
-        : expect.output.clone(format);
+      var expectForOutput = error.expect || expect;
+      var output = expectForOutput.createOutput
+        ? expectForOutput.createOutput(format)
+        : expectForOutput.output.clone(format);
       return error.getErrorMessage({ output: output }).toString(format);
     } else if (error.output) {
       return error.output.toString(format);


### PR DESCRIPTION
Fixes update-examples that relies on eg. styles defined by magicpen-media in an expect.child.

I ran into this while testing https://github.com/unexpectedjs/unexpected-markdown/pull/49 in unexpected-resemble :)